### PR TITLE
bugfix for jwt.decode

### DIFF
--- a/core/api/jwt.py
+++ b/core/api/jwt.py
@@ -38,7 +38,6 @@ def cognito_jwt_decode_handler(token):
         return jwt.decode(
             token,
             public_key,
-            api_settings.JWT_VERIFY,
             options=options,
             leeway=api_settings.JWT_LEEWAY,
             audience=api_settings.JWT_AUDIENCE,


### PR DESCRIPTION
Since v2.0 of PyJWT the 'verify_signature' option is True by default and explicitly setting "api_settings.JWT_VERIFY," in the new decode arguments causes the TypeError: decode() got multiple values for argument 'algorithms' problem. Removing that from the decode call fixes the issue.